### PR TITLE
WA-21420: Add C# KYC documents upload example

### DIFF
--- a/examples/csharp/App/App.csproj
+++ b/examples/csharp/App/App.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/csharp/App/Program.cs
+++ b/examples/csharp/App/Program.cs
@@ -39,6 +39,7 @@ namespace App
         private const string FilePath = "../../testdata/file_name.jpg";
 
         #if READ_KEYS_FROM_STRINGS
+            // Replace this with actual private key
             private const string PrivateKeyPem = """
             -----BEGIN RSA PRIVATE KEY-----
             ...
@@ -47,6 +48,7 @@ namespace App
             -----END RSA PRIVATE KEY-----
             """;
 
+            // Replace this with actual public key
             private const string PublicKeyPem = """
             -----BEGIN PUBLIC KEY-----
             ...

--- a/examples/csharp/App/Program.cs
+++ b/examples/csharp/App/Program.cs
@@ -259,11 +259,6 @@ namespace App
 
         private static string CalculateRequestBodyHash(byte[] body)
         {
-            if (body.Length == 0)
-            {
-                return string.Empty;
-            }
-
             using var sha256 = SHA256.Create();
             {
                 var hash = SHA256.HashData(body);

--- a/examples/csharp/App/Program.cs
+++ b/examples/csharp/App/Program.cs
@@ -60,12 +60,14 @@ namespace App
 
         public static void Main(string[] args)
         {
+            SigningCredentials signingCredentials;
+            SecurityKey wallesterPublicKey;
             #if READ_KEYS_FROM_STRINGS
-                var signingCredentials = ReadSigningCredentialsFromString(PrivateKeyPem);
-                var wallesterPublicKey = ReadPublicKeyFromString(PublicKeyPem);
+                signingCredentials = ReadSigningCredentialsFromString(PrivateKeyPem);
+                wallesterPublicKey = ReadPublicKeyFromString(PublicKeyPem);
             #else
-                var signingCredentials = ReadSigningCredentials("../../keys/example_private.pkcs12", "123456");
-                var wallesterPublicKey = ReadPublicKey("../../keys/example_wallester_public.cer");
+                signingCredentials = ReadSigningCredentials("../../keys/example_private.pkcs12", "123456");
+                wallesterPublicKey = ReadPublicKey("../../keys/example_wallester_public.cer");
             #endif
 
             var response = ExecuteRequest(signingCredentials);
@@ -84,7 +86,7 @@ namespace App
             return new SigningCredentials(key, SecurityAlgorithms.RsaSha256);
         }
 
-        private static RsaSecurityKey ReadPublicKeyFromString(string publicKeyPem)
+        private static SecurityKey ReadPublicKeyFromString(string publicKeyPem)
         {
             var rsa = RSA.Create();
             rsa.ImportFromPem(publicKeyPem.ToCharArray());

--- a/examples/csharp/App/Program.cs
+++ b/examples/csharp/App/Program.cs
@@ -1,7 +1,12 @@
-﻿using System;
+﻿// #define READ_KEYS_FROM_STRINGS
+// #define UPLOAD_KYC_DOCUMENTS // Uncomment this line to send upload kyc documents request
+
+using System;
 using System.IdentityModel.Tokens.Jwt;
 using System.IO;
-using System.Net;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Security.Claims;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
@@ -14,36 +19,162 @@ namespace App
     class Program
     {
         // Replace this with the actual issuer ID you've got from Wallester
-        private static string _issuer = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx";
+        private const string Issuer = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx";
 
         // Replace this with the actual audience ID you've got from Wallester
-        private static string _audience = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx";
+        private const string Audience = "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX";
 
         // Replace this with actual Wallester API URL
-        private static string _apiURL = "https://xxx.wallester.eu/v1/test/ping";
+        private const string ApiUrl = "https://xxx.wallester.eu";
+        private const string PingPath = "/v1/test/ping";
+        private const string UploadKycDocumentPath = "/v1/kyc-documents";
 
-        private static string _subject = "api-request";
+        private const string Subject = "api-request";
+
+        // Replace this with actual data to send upload kyc documents request
+        private const string AuditSourceType = "Backend";
+        private const string AuditUserId = "integration-example";
+        private const string ProductCode = "PRODUCTCODE";
+        private const string KycCheckId = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx";
+        private const string FilePath = "../../testdata/file_name.jpg";
+
+        #if READ_KEYS_FROM_STRINGS
+            private const string PrivateKeyPem = """
+            -----BEGIN RSA PRIVATE KEY-----
+            ...
+            ...
+            ...
+            -----END RSA PRIVATE KEY-----
+            """;
+
+            private const string PublicKeyPem = """
+            -----BEGIN PUBLIC KEY-----
+            ...
+            ...
+            ...
+            -----END PUBLIC KEY-----
+            """;
+        #endif
 
         public static void Main(string[] args)
         {
-            var signingCredentials = ReadSigningCredentials("../../keys/example_private.pkcs12", "123456");
-            var wallesterPublicKey = ReadPublicKey("../../keys/example_wallester_public.cer");
+            #if READ_KEYS_FROM_STRINGS
+                var signingCredentials = ReadSigningCredentialsFromString(PrivateKeyPem);
+                var wallesterPublicKey = ReadPublicKeyFromString(PublicKeyPem);
+            #else
+                var signingCredentials = ReadSigningCredentials("../../keys/example_private.pkcs12", "123456");
+                var wallesterPublicKey = ReadPublicKey("../../keys/example_wallester_public.cer");
+            #endif
 
-            var request = new PingRequest
+            var responseBody = ExecuteRequest(signingCredentials, wallesterPublicKey);
+
+            Console.WriteLine("Response: " + responseBody);
+        }
+
+        private static string ExecuteRequest(SigningCredentials signingCredentials, SecurityKey wallesterPublicKey)
+        {
+            #if UPLOAD_KYC_DOCUMENTS
+                return ExecuteUploadKycRequest(signingCredentials, wallesterPublicKey);
+            #else
+                return ExecutePingRequest(signingCredentials, wallesterPublicKey);
+            #endif
+        }
+
+        private static string ExecutePingRequest(SigningCredentials signingCredentials, SecurityKey wallesterPublicKey)
+        {
+            var request = new PingRequest { Message = "ping" };
+            var json = JsonConvert.SerializeObject(request);
+            var content = new StringContent(json, Encoding.UTF8, "application/json");
+
+            return ExecuteHttpRequest(content, PingPath, signingCredentials, wallesterPublicKey);
+        }
+
+        private static string ExecuteUploadKycRequest(SigningCredentials signingCredentials, SecurityKey wallesterPublicKey)
+        {
+            if (!File.Exists(FilePath))
             {
-                Message = "ping"
-            };
-            var requestBody = JsonConvert.SerializeObject(request);
-
-            var responseBody = DoRequest(requestBody, signingCredentials, wallesterPublicKey);
-
-            var response = JsonConvert.DeserializeObject<PingResponse>(responseBody);
-            if (response.Message != "pong")
-            {
-                throw new ApplicationException("Invalid response message, expected 'pong', got '" + response.Message + "'");
+                throw new FileNotFoundException("The file was not found", FilePath);
             }
 
-            Console.ReadKey();
+            var fileBytes = File.ReadAllBytes(FilePath);
+            var uploadRequest = new UploadKycDocumentRequest
+            {
+                KycCheckId = KycCheckId,
+                Type = "IDVSelfieImage",
+                FileContent = fileBytes,
+                FileName = Path.GetFileName(FilePath)
+            };
+
+            var content = CreateMultipartContent(uploadRequest);
+            return ExecuteHttpRequest(content, UploadKycDocumentPath, signingCredentials, wallesterPublicKey);
+        }
+
+        private static MultipartFormDataContent CreateMultipartContent(UploadKycDocumentRequest uploadRequest)
+        {
+            var fileContent = new ByteArrayContent(uploadRequest.FileContent);
+            fileContent.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
+
+            var formDataContent = new MultipartFormDataContent();
+            formDataContent.Add(new StringContent(uploadRequest.KycCheckId), "kyc_check_id");
+            formDataContent.Add(new StringContent(uploadRequest.Type), "type");
+            formDataContent.Add(fileContent, "file", uploadRequest.FileName);
+
+            return formDataContent;
+        }
+
+        private static string ExecuteHttpRequest(HttpContent content, string path, SigningCredentials signingCredentials, SecurityKey wallesterPublicKey)
+        {
+            var requestBodyHash = CalculateRequestBodyHash(content.ReadAsByteArrayAsync().Result);
+            var token = CreateToken(requestBodyHash, signingCredentials);
+            Console.WriteLine("Request JWT token: " + token);
+
+            using var client = new HttpClient();
+            SetDefaultHeaders(client);
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+            var apiPath = ApiUrl + path;
+            var response = client.PostAsync(apiPath, content).Result;
+            var responseString = response.Content.ReadAsStringAsync().Result;
+
+            ValidateResponse(response, responseString, wallesterPublicKey);
+
+            return responseString;
+        }
+
+        private static void SetDefaultHeaders(HttpClient client)
+        {
+            client.DefaultRequestHeaders.Add("X-Audit-Source-Type", AuditSourceType);
+            client.DefaultRequestHeaders.Add("X-Audit-User-Id", AuditUserId);
+            client.DefaultRequestHeaders.Add("X-Product-Code", ProductCode);
+        }
+
+        private static void ValidateResponse(HttpResponseMessage response, string responseString, SecurityKey wallesterPublicKey)
+        {
+            if (!response.Headers.TryGetValues("Authorization", out var bearerHeader))
+            {
+                Console.WriteLine("The response does not contain the Authorization header");
+                return;
+            }
+
+            var responseToken = bearerHeader.FirstOrDefault()?.Replace("Bearer ", "");
+            if (responseToken == null)
+            {
+                Console.WriteLine("The Authorization header is missing the Bearer token");
+                return;
+            }
+
+            Console.WriteLine("Response JWT token: " + responseToken);
+            var responseBodyHash = CalculateRequestBodyHash(Encoding.UTF8.GetBytes(responseString));
+
+            try
+            {
+                VerifyToken(responseToken, responseBodyHash, wallesterPublicKey);
+                Console.WriteLine("Response is trusted");
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine("Response is not trusted: " + e);
+            }
         }
 
         // Reads signing credentials from a certificate file
@@ -59,7 +190,7 @@ namespace App
         {
             SecurityKey key;
 
-            using (var f = new FileStream(filename, FileMode.Open, FileAccess.Read))
+            using var f = new FileStream(filename, FileMode.Open, FileAccess.Read);
             {
                 var size = (int)f.Length;
                 var rawData = new byte[size];
@@ -72,50 +203,32 @@ namespace App
             return key;
         }
 
-        private static string DoRequest(string requestBody, SigningCredentials signingCredentials, SecurityKey wallesterPublicKey)
+        private static SigningCredentials ReadSigningCredentialsFromString(string privateKeyPem)
         {
-            var requestBodyHash = CalculateRequestBodyHash(requestBody);
-            var token = CreateToken(requestBodyHash, signingCredentials);
+            var rsa = RSA.Create();
+            rsa.ImportFromPem(privateKeyPem.ToCharArray());
 
-            Console.WriteLine("Request JWT token: " + token);
-
-            string responseString;
-
-            using (var client = new WebClient())
-            {
-                client.Headers[HttpRequestHeader.ContentType] = "application/json";
-                client.Headers[HttpRequestHeader.Authorization] = "Bearer " + token;
-                responseString = client.UploadString(_apiURL, "POST", requestBody);
-                var bearer = client.ResponseHeaders[HttpRequestHeader.Authorization];
-                var responseToken = bearer.Replace("Bearer ", "");
-
-                Console.WriteLine("Response JWT token: " + responseToken);
-
-                var responseBodyHash = CalculateRequestBodyHash(responseString);
-
-                try
-                {
-                    VerifyToken(responseToken, responseBodyHash, wallesterPublicKey);
-                    Console.WriteLine("Response is trusted");
-                }
-                catch (Exception e)
-                {
-                    Console.WriteLine("Response is not trusted: " + e);
-                }
-            }
-
-            return responseString;
+            var key = new RsaSecurityKey(rsa);
+            return new SigningCredentials(key, SecurityAlgorithms.RsaSha256);
         }
 
-        private static void VerifyToken(String token, String responseBodyHash, SecurityKey wallesterPublicKey)
+        private static RsaSecurityKey ReadPublicKeyFromString(string publicKeyPem)
+        {
+            var rsa = RSA.Create();
+            rsa.ImportFromPem(publicKeyPem.ToCharArray());
+
+            return new RsaSecurityKey(rsa);
+        }
+
+        private static void VerifyToken(string token, string responseBodyHash, SecurityKey wallesterPublicKey)
         {
             var tokenValidationParameters = new TokenValidationParameters
             {
                 RequireExpirationTime = true,
                 RequireSignedTokens = true,
-                ValidAudience = _issuer,
+                ValidAudience = Issuer,
                 ValidateAudience = true,
-                ValidIssuer = _audience,
+                ValidIssuer = Audience,
                 ValidateIssuer = true,
                 ValidateLifetime = true,
                 IssuerSigningKey = wallesterPublicKey,
@@ -138,29 +251,37 @@ namespace App
             }
 
             var jwtToken = new JwtSecurityToken(token);
-            if (jwtToken.Subject != _subject)
+            if (jwtToken.Subject != Subject)
             {
                 throw new ApplicationException("invalid subject: " + jwtToken.Subject);
             }
         }
 
-        private static string CalculateRequestBodyHash(string body)
+        private static string CalculateRequestBodyHash(byte[] body)
         {
-            var bytes = Encoding.UTF8.GetBytes(body);
-            var hash = new SHA256Managed().ComputeHash(bytes);
-            return Convert.ToBase64String(hash);
+            if (body.Length == 0)
+            {
+                return string.Empty;
+            }
+
+            using var sha256 = SHA256.Create();
+            {
+                var hash = SHA256.HashData(body);
+                return Convert.ToBase64String(hash);
+            }
         }
 
         private static string CreateToken(string requestBodyHash, SigningCredentials signingCredentials)
         {
-            Claim[] claims = {
-                new Claim("sub", _subject),
+            var claims = new[]
+            {
+                new Claim("sub", Subject),
                 new Claim("rbh", requestBodyHash)
             };
 
             var notBefore = DateTime.UtcNow;
             var expires = DateTime.UtcNow.AddMinutes(1);
-            var token = new JwtSecurityToken(_issuer, _audience, claims, notBefore, expires, signingCredentials);
+            var token = new JwtSecurityToken(Issuer, Audience, claims, notBefore, expires, signingCredentials);
 
             var handler = new JwtSecurityTokenHandler();
             return handler.WriteToken(token);

--- a/examples/csharp/App/UploadKYCDocumentRequest.cs
+++ b/examples/csharp/App/UploadKYCDocumentRequest.cs
@@ -1,0 +1,19 @@
+using Newtonsoft.Json;
+
+namespace App
+{
+    public class UploadKycDocumentRequest
+    {
+        [JsonProperty("kyc_check_id")]
+        public string KycCheckId { get; set; }
+
+        [JsonProperty("type")]
+        public string Type { get; set; }
+        
+        [JsonIgnore]
+        public byte[] FileContent { get; set; }
+        
+        [JsonIgnore]
+        public string FileName { get; set; }
+    }
+}

--- a/examples/csharp/App/UploadKYCDocumentResponse.cs
+++ b/examples/csharp/App/UploadKYCDocumentResponse.cs
@@ -1,0 +1,10 @@
+using Newtonsoft.Json;
+
+namespace App
+{
+    public class UploadKycDocumentResponse
+    {
+        [JsonProperty("kyc_document_id")]
+        public string KycDocumentId { get; set; }
+    }
+}

--- a/examples/csharp/Makefile
+++ b/examples/csharp/Makefile
@@ -1,10 +1,9 @@
 
 default: 
-	@msbuild App.sln /t:Build /p:Configuration=Release
+	@dotnet build App.sln --configuration Release
 
 deps:
-	@nuget restore
+	@dotnet restore
 
 run:
-	@dotnet App/bin/Release/netcoreapp2.0/App.dll
-
+	@dotnet App/bin/Release/netcoreapp8.0/App.dll


### PR DESCRIPTION
Since the client had difficulties sending a file in multipart form data, I added an example of sending KYC upload document. To send it you need to uncomment `#define UPLOAD_KYC_DOCUMENTS`