### PR TITLE
use correct framework

### DIFF
--- a/examples/csharp/App/App.csproj
+++ b/examples/csharp/App/App.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp8.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/csharp/Makefile
+++ b/examples/csharp/Makefile
@@ -6,4 +6,4 @@ deps:
 	@dotnet restore
 
 run:
-	@dotnet App/bin/Release/netcoreapp8.0/App.dll
+	@dotnet App/bin/Release/net8.0/App.dll


### PR DESCRIPTION
the undocumented names (without period in dotnet 5+) can drop their support when move to double-digit (to avoid potential conflicts) [learn.microsoft.com/en-us/dotnet/standard/frameworks#supported-target-frameworks](https://learn.microsoft.com/en-us/dotnet/standard/frameworks#supported-target-frameworks)